### PR TITLE
Add Swagger to generate api docs

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -40,7 +40,7 @@ gem 'rest-client'
 gem 'acts-as-taggable-on'
 
 # Documentation
-gem 'apipie-rails', '~> 0.2.6'
+gem 'swagger-docs'
 
 # CORS
 gem 'rack-cors'

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -38,20 +38,18 @@ GEM
       tzinfo (~> 1.1)
     acts-as-taggable-on (3.5.0)
       activerecord (>= 3.2, < 5)
-    apipie-rails (0.2.6)
-      json
     arel (6.0.0)
     ast (2.0.0)
     astrolabe (1.3.0)
       parser (>= 2.2.0.pre.3, < 3.0)
-    brakeman (3.0.3)
+    brakeman (3.0.5)
       erubis (~> 2.6)
       fastercsv (~> 1.5)
       haml (>= 3.0, < 5.0)
       highline (~> 1.6.20)
       multi_json (~> 1.2)
       ruby2ruby (~> 2.1.1)
-      ruby_parser (~> 3.6.2)
+      ruby_parser (~> 3.7.0)
       sass (~> 3.0)
       terminal-table (~> 1.4)
     builder (3.2.2)
@@ -88,11 +86,11 @@ GEM
     mime-types (2.6.1)
     mini_portile (0.6.2)
     minitest (5.7.0)
-    multi_json (1.11.0)
+    multi_json (1.11.1)
     netrc (0.10.3)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
-    parser (2.2.2.3)
+    parser (2.2.2.5)
       ast (>= 1.1, < 3.0)
     pg (0.18.2)
     powerpack (0.1.1)
@@ -102,7 +100,7 @@ GEM
       slop (~> 3.4)
     puma (2.11.3)
       rack (>= 1.1, < 2.0)
-    rack (1.6.2)
+    rack (1.6.4)
     rack-cors (0.4.0)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -156,9 +154,9 @@ GEM
       rspec-mocks (~> 3.3.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
-    rubocop (0.31.0)
+    rubocop (0.32.1)
       astrolabe (~> 1.3)
-      parser (>= 2.2.2.1, < 3.0)
+      parser (>= 2.2.2.5, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
@@ -168,24 +166,27 @@ GEM
     ruby2ruby (2.1.4)
       ruby_parser (~> 3.1)
       sexp_processor (~> 4.0)
-    ruby_parser (3.6.6)
+    ruby_parser (3.7.0)
       sexp_processor (~> 4.1)
-    sass (3.4.13)
-    sexp_processor (4.5.1)
+    sass (3.4.15)
+    sexp_processor (4.6.0)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
     slop (3.6.0)
     spring (1.3.6)
     sprockets (3.2.0)
       rack (~> 1.0)
-    sprockets-rails (2.3.1)
+    sprockets-rails (2.3.2)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    terminal-table (1.4.5)
+    swagger-docs (0.1.9)
+      activesupport (>= 3, < 5)
+      rails (>= 3, < 5)
+    terminal-table (1.5.1)
     thor (0.19.1)
     thread_safe (0.3.5)
-    tilt (1.4.1)
+    tilt (2.0.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     unf (0.1.4)
@@ -197,7 +198,6 @@ PLATFORMS
 
 DEPENDENCIES
   acts-as-taggable-on
-  apipie-rails (~> 0.2.6)
   brakeman
   database_cleaner (~> 1.3.0)
   dotenv-rails
@@ -214,6 +214,7 @@ DEPENDENCIES
   rubocop-checkstyle_formatter
   shoulda-matchers
   spring
+  swagger-docs
 
 BUNDLED WITH
-   1.10.4
+   1.10.5

--- a/api/app/controllers/application_controller.rb
+++ b/api/app/controllers/application_controller.rb
@@ -1,3 +1,2 @@
 class ApplicationController < ActionController::API
-  extend Apipie::DSL::Concern
 end

--- a/api/app/controllers/effects_controller.rb
+++ b/api/app/controllers/effects_controller.rb
@@ -1,6 +1,12 @@
 class EffectsController < ApplicationController
-  api :GET, '/effects/:id', 'Shows drug as returned from FDA with parsed effects by :id (Brand name of drug)'
-  param :id, String, required: true, desc: 'Brand name of drug'
+  swagger_controller :effects, 'Reported Drug Effects'
+
+  swagger_api :show do
+    summary 'Returns all reported effects for a drug.'
+    notes 'Effects can be reported as not existing or existing on the drug label'
+    param :path, :id, :string, :required, 'Brand name of drug'
+    response :not_found
+  end
 
   def show
     if drug.nil?
@@ -28,10 +34,26 @@ class EffectsController < ApplicationController
     end
   end
 
-  api :POST, '/events', 'Record new events response to question.'
+  swagger_api :create do
+    summary 'Create a new drug effect report.'
+    notes 'Effects can be reported as not existing or existing on the drug label'
+    param :form, :drug_name, :string, :required, 'Brand name of drug'
+    param :form, :effect, :string, :required, 'Effect name (lowercased)'
+    param :form, :response, :boolean, :required, 'Effect exists in label or has been experienced'
+    response :not_acceptable
+  end
 
   def create
     render json: Effect.create!(effect_params)
+  end
+
+  # Effect Model definition
+  swagger_model :Effect do
+    description 'Reported drug effect'
+    property :id, :integer, :required, 'Report id'
+    property :drug_name, :string, :required, 'Brand name of drug'
+    property :name, :string, :required, 'Effect name (lowercased)'
+    property :response, :boolean, :required, 'Effect exists in label or has been experienced'
   end
 
   private

--- a/api/app/controllers/leaders_controller.rb
+++ b/api/app/controllers/leaders_controller.rb
@@ -1,24 +1,44 @@
 class LeadersController < ApplicationController
-  api :GET, '/leaders', 'Returns all leaders'
+  swagger_controller :leaders, 'Leaderboard submissions'
+
+  swagger_api :index do
+    summary 'Returns all leaderboard submissions.'
+    notes 'Names are returned ordered by the number of submissions'
+  end
 
   def index
     render json: leaders
   end
 
-  api :POST, '/leaders', 'Create or updates existing leaders found by name'
-  param :name, String, desc: 'Leader name'
-  param :total, Integer, desc: 'Leader total'
-  param :zipcode, String, desc: 'Leader zipcode'
+  swagger_api :create do
+    summary 'Create a new leaderboard submission.'
+    param :form, :name, :string, :required, 'Participant name'
+    param :form, :total, :integer, :required, 'Number of ...'
+    param :form, :zipcode, :string, :required, 'Participant zipcode'
+    response :not_acceptable
+  end
 
   def create
     leader.increment! :count
     render json: leader
   end
 
-  api :GET, '/leaders/latest', 'Returns 10 leaders sorted by updated_at'
+  swagger_api :latest do
+    summary 'Returns the 10 most recent leaderboard submissions.'
+    notes 'Names are returned ordered by the submission time'
+  end
 
   def latest
     render json: Leader.order(:updated_at).limit(10)
+  end
+
+  # Leader Model definition
+  swagger_model :Leader do
+    description 'Leaderboard particpant submission'
+    property :id, :integer, :required, 'Submission id'
+    property :name, :string, :required, 'Participant'
+    property :count, :integer, :required, 'Count of ...'
+    property :zipcode, :string, :required, 'Participant zipcode'
   end
 
   private

--- a/api/config/initializers/apipie.rb
+++ b/api/config/initializers/apipie.rb
@@ -1,9 +1,0 @@
-Apipie.configure do |config|
-  config.app_name                = 'API'
-  config.api_base_url            = '/api/v1'
-  config.doc_base_url            = '/documentation'
-  # where is your API defined?
-  config.api_controllers_matcher = "#{Rails.root}/app/controllers/*.rb"
-  config.reload_controllers = true
-  config.show_all_examples = true
-end

--- a/api/config/initializers/swagger_docs.rb
+++ b/api/config/initializers/swagger_docs.rb
@@ -1,0 +1,36 @@
+module Swagger
+  module Docs
+    class Generator
+      def self.trim_slashes(str)
+        '/' + trim_leading_slash(trim_trailing_slash(str))
+      end
+    end
+
+    Config.base_api_controller = ActionController::API
+    Config.register_apis(
+      '1.0' => {
+        # where to find controllers in relation to app/controllers
+        controller_base_path: '',
+        # the extension used for the API
+        api_extension_type: :json,
+        # the output location where your .json files are written to
+        api_file_path: '../www/docs/api/',
+        # the URL base path to your API
+        base_path: '/',
+        # if you want to delete all .json files at each generation
+        clean_directory: true,
+        # add custom attributes to api-docs
+        attributes: {
+          info: {
+            'title' => 'ADS labelcraft API',
+            'description' => 'API backend',
+            'termsOfServiceUrl' => 'https://github.com/booz-allen-agile-delivery/ads-final',
+            'contact' => 'apiteam@wordnik.com',
+            'license' => 'Apache 2.0',
+            'licenseUrl' => 'http://www.apache.org/licenses/LICENSE-2.0.html'
+          }
+        }
+      }
+    )
+  end
+end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -1,7 +1,4 @@
 Rails.application.routes.draw do
-  # Documentation
-  apipie
-
   scope '/api/v1', except: [:new, :edit], defaults: { format: :json } do
     resources :effects, only: [:show, :create]
     resources :leaders, only: [:index, :create] do


### PR DESCRIPTION
- Removed apipie
- Generate Swagger docs with `bundle exec rake swagger:docs`
- Docs are generated into www/docs/api

@wbchaf
